### PR TITLE
PWX-26400: Updating sample app to work without region for fb and upda…

### DIFF
--- a/examples/cr/fb/multiple/pba2.yaml
+++ b/examples/cr/fb/multiple/pba2.yaml
@@ -1,0 +1,8 @@
+apiVersion: object.portworx.io/v1alpha1
+kind: PXBucketAccess
+metadata:
+  name: fb-pba-2
+  namespace: default
+spec:
+  bucketClassName: pbclass-fb
+  bucketClaimName: fb-pbc-2

--- a/examples/cr/fb/multiple/pbc2.yaml
+++ b/examples/cr/fb/multiple/pbc2.yaml
@@ -1,0 +1,7 @@
+apiVersion: object.portworx.io/v1alpha1
+kind: PXBucketClaim
+metadata:
+  name: fb-pbc-2
+  namespace: default
+spec:
+  bucketClassName: pbclass-fb

--- a/examples/sample-app/main.go
+++ b/examples/sample-app/main.go
@@ -15,6 +15,11 @@ import (
 )
 
 func main() {
+	const (
+		S3            = "s3"
+		DefaultRegion = "default"
+	)
+
 	accessKey := os.Getenv("S3_ACCESS_KEY_1")
 	secretKey := os.Getenv("S3_SECRET_KEY_1")
 	bucketName := os.Getenv(("S3_BUCKET_NAME_1"))
@@ -30,7 +35,13 @@ func main() {
 		if err != nil {
 			fmt.Printf("bad credentials: %s", err)
 		}
-		cfg := aws.NewConfig().WithEndpoint(endpointStr).WithRegion(regionStr).WithDisableSSL(true).WithCredentials(creds).WithS3ForcePathStyle(true)
+		cfg := aws.NewConfig().WithEndpoint(endpointStr).WithDisableSSL(true).WithCredentials(creds).WithS3ForcePathStyle(true)
+		if len(regionStr) > 0 {
+			cfg = cfg.WithRegion(regionStr)
+		} else {
+			cfg = cfg.WithRegion(DefaultRegion)
+		}
+
 		svc := s3.New(session.New(), cfg)
 		objName := uuid.New().String()
 		fmt.Printf("--- PUT OBJECT %s IN BUCKET %s ---\n", objName, bucketName)
@@ -45,7 +56,12 @@ func main() {
 		if err != nil {
 			fmt.Printf("bad credentials: %s", err)
 		}
-		cfg = aws.NewConfig().WithEndpoint(endpointStr).WithRegion(regionStr).WithDisableSSL(true).WithCredentials(creds).WithS3ForcePathStyle(true)
+		cfg = aws.NewConfig().WithEndpoint(endpointStr).WithDisableSSL(true).WithCredentials(creds).WithS3ForcePathStyle(true)
+		if len(regionStr) > 0 {
+			cfg = cfg.WithRegion(regionStr)
+		} else {
+			cfg = cfg.WithRegion(DefaultRegion)
+		}
 		svc = s3.New(session.New(), cfg)
 		objName = uuid.New().String()
 		fmt.Printf("--- PUT OBJECT %s IN BUCKET %s ---\n", objName, bucketNameTwo)

--- a/examples/sample-app/sample-app-fb.yaml
+++ b/examples/sample-app/sample-app-fb.yaml
@@ -29,41 +29,36 @@ spec:
           - name: S3_ACCESS_KEY_1
             valueFrom:
                 secretKeyRef:
-                  name: px-os-credentials-s3-pba
+                  name: px-os-credentials-fb-pba
                   key: access-key-id
           - name: S3_SECRET_KEY_1
             valueFrom:
                 secretKeyRef:
-                  name: px-os-credentials-s3-pba
+                  name: px-os-credentials-fb-pba
                   key: secret-access-key
           - name: S3_BUCKET_NAME_1
             valueFrom:
                 secretKeyRef:
-                  name: px-os-credentials-s3-pba
+                  name: px-os-credentials-fb-pba
                   key: bucket-id
           - name: S3_ACCESS_KEY_2
             valueFrom:
                 secretKeyRef:
-                  name: px-os-credentials-s3-pba-2
+                  name: px-os-credentials-fb-pba-2
                   key: access-key-id
           - name: S3_SECRET_KEY_2
             valueFrom:
                 secretKeyRef:
-                  name: px-os-credentials-s3-pba-2
+                  name: px-os-credentials-fb-pba-2
                   key: secret-access-key
           - name: S3_BUCKET_NAME_2
             valueFrom:
                 secretKeyRef:
-                  name: px-os-credentials-s3-pba-2
+                  name: px-os-credentials-fb-pba-2
                   key: bucket-id
           - name: S3_ENDPOINT
             valueFrom:
                 secretKeyRef:
-                  name: px-os-credentials-s3-pba
+                  name: px-os-credentials-fb-pba
                   key: endpoint
-          - name: S3_REGION
-            valueFrom:
-                secretKeyRef:
-                  name: px-os-credentials-s3-pba
-                  key: region
     


### PR DESCRIPTION
…ting cr yaml

Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

**What this PR does / why we need it**:
PWX-26400 [https://portworx.atlassian.net/browse/PWX-26400]

**Which issue(s) this PR fixes** (optional)
Sample app doesn't work without region in the sample yaml for pure fb.
Fixing  the yaml to use separate pba objects in the app.

**Special notes for your reviewer**:
1. Provided second copy of pba and pbc for pure fb.
2. Updated the sample app to pass "default" region in case of missing region as s3 APIs expect a non empty region field.
3. Provided a separate yaml for fb.
4. Fixed the bucket access in the s3 yaml.
